### PR TITLE
Refactor Convert & Parse function to use RomanNumerals type

### DIFF
--- a/roman.go
+++ b/roman.go
@@ -6,9 +6,32 @@ import (
 )
 
 type RomanNumeralErr string
+type RomanNumeral struct {
+	Value  int
+	Symbol string
+}
+type RomanNumerals []RomanNumeral
 
 func (e RomanNumeralErr) Error() string {
 	return string(e)
+}
+
+func (rs RomanNumerals) ValueOf(symbol string) int {
+	for _, r := range rs {
+		if r.Symbol == symbol {
+			return r.Value
+		}
+	}
+	return 0
+}
+
+func (rs RomanNumerals) Exists(symbol string) bool {
+	for _, r := range rs {
+		if r.Symbol == symbol {
+			return true
+		}
+	}
+	return false
 }
 
 const (
@@ -18,52 +41,33 @@ const (
 	VALUE_ERROR  = RomanNumeralErr("value over-over limit. 1 - 3999999")
 )
 
-var (
-	romanMapValues = map[string]int{
-		"I":  1,
-		"V":  5,
-		"X":  10,
-		"L":  50,
-		"C":  100,
-		"D":  500,
-		"M":  1000,
-		"_I": 1000,
-		"_V": 5000,
-		"_X": 10000,
-		"_L": 50000,
-		"_C": 100000,
-		"_D": 500000,
-		"_M": 1000000,
-	}
-	valueMapRomans = map[int]string{
-		1000000: "_M",
-		900000:  "_C_M",
-		500000:  "_D",
-		400000:  "_C_D",
-		100000:  "_C",
-		90000:   "_X_C",
-		50000:   "_L",
-		40000:   "_X_L",
-		10000:   "_X",
-		9000:    "_I_X",
-		5000:    "_V",
-		4000:    "_I_V",
-		1000:    "M",
-		900:     "CM",
-		500:     "D",
-		400:     "CD",
-		100:     "C",
-		90:      "XC",
-		50:      "L",
-		40:      "XL",
-		10:      "X",
-		9:       "IX",
-		5:       "V",
-		4:       "IV",
-		1:       "I",
-	}
-	valueIndex = []int{1000000, 900000, 500000, 400000, 100000, 90000, 50000, 40000, 10000, 9000, 5000, 4000, 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1}
-)
+var allRomanNumerals = RomanNumerals{
+	{1000000, "_M"},
+	{900000, "_C_M"},
+	{500000, "_D"},
+	{400000, "_C_D"},
+	{100000, "_C"},
+	{90000, "_X_C"},
+	{50000, "_L"},
+	{40000, "_X_L"},
+	{10000, "_X"},
+	{9000, "_I_X"},
+	{5000, "_V"},
+	{4000, "_I_V"},
+	{1000, "M"},
+	{900, "CM"},
+	{500, "D"},
+	{400, "CD"},
+	{100, "C"},
+	{90, "XC"},
+	{50, "L"},
+	{40, "XL"},
+	{10, "X"},
+	{9, "IX"},
+	{5, "V"},
+	{4, "IV"},
+	{1, "I"},
+}
 
 // Convert takes roman numeral into arabic number
 //
@@ -74,26 +78,30 @@ func Convert(roman string) (int, error) {
 	if !Validate(roman) {
 		return 0, FORMAT_ERROR
 	}
-	romanValue := 0
-	latestValue := 0
+	total := 0
 	for i := 0; i < len(roman); i++ {
-		key := roman[i : i+1]
-		if key == "_" {
-			key = roman[i : i+2]
+		iLength := 1
+		currentIndex := i
+		if roman[currentIndex:currentIndex+iLength] == "_" {
+			iLength = 2
 			i++
 		}
-		value := romanMapValues[key]
-		if latestValue != 0 && latestValue < value {
-			romanValue += value - (2 * latestValue)
-		} else {
-			romanValue += value
+		symbol := roman[currentIndex : currentIndex+iLength]
+		if currentIndex+(2*iLength)-1 < len(roman) && IsSubstractive(symbol) {
+			potentialNumber := roman[currentIndex : currentIndex+(2*iLength)]
+			value := allRomanNumerals.ValueOf(potentialNumber)
+			if value != 0 {
+				total += value
+				i += iLength
+				continue
+			}
 		}
-		latestValue = value
+		total += allRomanNumerals.ValueOf(symbol)
 	}
-	if romanValue > LIMIT_VALUE {
-		return romanValue, VALUE_ERROR
+	if total > LIMIT_VALUE {
+		return total, VALUE_ERROR
 	}
-	return romanValue, nil
+	return total, nil
 }
 
 // Parse format arabic number into roman numeral
@@ -105,24 +113,28 @@ func Parse(arabic int) (string, error) {
 		return "", VALUE_ERROR
 	}
 	value := arabic
-	roman := ""
-	for value > 0 {
-		key := 0
-		for _, k := range valueIndex {
-			if k <= value {
-				key = k
-				break
-			}
+	var roman strings.Builder
+
+	for _, r := range allRomanNumerals {
+		for value >= r.Value {
+			roman.WriteString(r.Symbol)
+			value -= r.Value
 		}
-		roman += valueMapRomans[key]
-		value -= key
 	}
 
-	return roman, nil
+	return roman.String(), nil
 }
 
 // Validate check roman format string
 func Validate(roman string) bool {
 	romanValidPattern, _ := regexp.Compile(PATTERN)
 	return romanValidPattern.MatchString(roman)
+}
+
+// IsSubstractive check if symbol can do substraction
+func IsSubstractive(symbol string) bool {
+	if symbol == "I" || symbol == "X" || symbol == "C" || symbol == "_I" || symbol == "_X" || symbol == "_C" {
+		return true
+	}
+	return false
 }

--- a/roman_test.go
+++ b/roman_test.go
@@ -3,6 +3,7 @@ package romanconv
 import (
 	"fmt"
 	"testing"
+	"testing/quick"
 )
 
 func TestConvert(t *testing.T) {
@@ -120,6 +121,20 @@ func TestParse(t *testing.T) {
 	})
 }
 
+func TestPropertiesOfConvertions(t *testing.T) {
+	assertion := func(arabic int) bool {
+		if arabic < 0 || arabic > 3999999 {
+			return true
+		}
+		roman, _ := Parse(arabic)
+		fromRoman, _ := Convert(roman)
+		return fromRoman == arabic
+	}
+	if err := quick.Check(assertion, nil); err != nil {
+		t.Error("convertion error", err)
+	}
+}
+
 func ExampleConvert() {
 	roman := "_M_D_C_L_X_VMDCLXVI"
 	arabic, _ := Convert(roman)
@@ -136,12 +151,18 @@ func ExampleParse() {
 
 func BenchmarkConvert(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		Convert("_M_D_C_L_X_VMDCLXVI")
+		Convert("_M_M_M_C_M_X_C_I_XCMXCIX")
 	}
 }
+
+// v1.0.0: BenchmarkConvert-4   	   20828	     56474 ns/op	   60810 B/op	     386 allocs/op
+// v1.0.1: BenchmarkConvert-4   	   21126	     56476 ns/op	   60803 B/op	     386 allocs/op
 
 func BenchmarkParse(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Parse(i)
 	}
 }
+
+// v1.0.0: BenchmarkParse-4   	 1664641	       723.1 ns/op	     148 B/op	      10 allocs/op
+// v1.0.1: BenchmarkParse-4   	48186309	        20.95 ns/op	       4 B/op	       0 allocs/op


### PR DESCRIPTION
Refactor to use `RomanNumerals` type on functions:

- Convert
- Parse

Add helper function `IsSubstractive`